### PR TITLE
Delayed import of db in experiments.

### DIFF
--- a/pprof/experiments/compilestats.py
+++ b/pprof/experiments/compilestats.py
@@ -9,8 +9,6 @@ by llvm
 
 from pprof.experiment import step, substep, RuntimeExperiment
 from os import path
-from pprof.utils.schema import CompileStat
-
 
 class CompilestatsExperiment(RuntimeExperiment):
     """The compilestats experiment."""
@@ -25,6 +23,7 @@ class CompilestatsExperiment(RuntimeExperiment):
 
     def run_project(self, p):
         """Compile & Run the experiment."""
+        from pprof.utils.schema import CompileStat
         from pprof.settings import config
         from pprof.utils.run import partial
 

--- a/pprof/experiments/papi.py
+++ b/pprof/experiments/papi.py
@@ -8,7 +8,6 @@ project with libpprof support to work.
 from pprof.experiment import (RuntimeExperiment, step, substep)
 from pprof.experiments.raw import run_with_time
 from pprof.utils.run import partial
-from pprof.utils.schema import CompileStat
 from plumbum import local
 from os import path
 
@@ -30,6 +29,7 @@ def collect_compilestats(project, experiment, config, clang, **kwargs):
     from pprof.settings import config as c
     from pprof.utils.db import persist_compilestats
     from pprof.utils.run import handle_stdin
+    from pprof.utils.schema import CompileStat
 
     c.update(config)
     clang = handle_stdin(clang["-mllvm", "-stats"], kwargs)

--- a/pprof/experiments/polyjit.py
+++ b/pprof/experiments/polyjit.py
@@ -7,7 +7,6 @@ when running with polyjit support enabled.
 from pprof.experiments.compilestats import get_compilestats
 from pprof.experiment import step, substep, RuntimeExperiment
 from pprof.utils.run import partial
-from pprof.utils.schema import CompileStat
 
 from plumbum import local
 from abc import abstractmethod
@@ -20,6 +19,7 @@ def collect_compilestats(project, experiment, config, clang, **kwargs):
     from pprof.settings import config as c
     from pprof.utils.db import persist_compilestats
     from pprof.utils.run import handle_stdin
+    from pprof.utils.schema import CompileStat
 
     c.update(config)
     clang = handle_stdin(clang["-mllvm", "-stats"], kwargs)
@@ -445,6 +445,7 @@ class PJITcs(PolyJIT):
 
     def run_project(self, p):
         from pprof.settings import config
+        from pprof.utils.schema import CompileStat
 
         p = self.init_project(p)
         with local.env(PPROF_ENABLE=0):


### PR DESCRIPTION
This makes it possible to load the configuration file before the
database is initialized.