### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/pprof/driver.py
+++ b/pprof/driver.py
@@ -55,7 +55,7 @@ class PollyProfiling(cli.Application):
                 print("Configuration loaded from file " + self._config_path)
 
         if args:
-            print "Unknown command %r" % (args[0],)
+            print "Unknown command {0!r}".format(args[0])
             return 1
         if not self.nested_command:
             print "No command given"

--- a/pprof/experiments/papi.py
+++ b/pprof/experiments/papi.py
@@ -60,9 +60,9 @@ def run_with_time(run_f, args, **kwargs):
     assert p is not None, "run_with_time.project attribute is None."
     assert e is not None, "run_with_time.experiment attribute is None."
     assert c is not None, "run_with_time.config attribute is None."
-    assert isinstance(p, Project), "Wrong type: %r Want: Project" % p
-    assert isinstance(e, Experiment), "Wrong type: %r Want: Experiment" % e
-    assert isinstance(c, dict), "Wrong type: %r Want: dict" % c
+    assert isinstance(p, Project), "Wrong type: {0!r} Want: Project".format(p)
+    assert isinstance(e, Experiment), "Wrong type: {0!r} Want: Experiment".format(e)
+    assert isinstance(c, dict), "Wrong type: {0!r} Want: dict".format(c)
 
     project_name = kwargs.get("project_name", p.name)
     timing_tag = "PPROF-PAPI: "

--- a/pprof/experiments/polyjit.py
+++ b/pprof/experiments/polyjit.py
@@ -47,9 +47,9 @@ def run_raw(run_f, args, **kwargs):
     assert p is not None, "run_raw.project attribute is None."
     assert e is not None, "run_raw.experiment attribute is None."
     assert c is not None, "run_raw.config attribute is None."
-    assert isinstance(p, Project), "Wrong type: %r Want: Project" % p
-    assert isinstance(e, Experiment), "Wrong type: %r Want: Experiment" % e
-    assert isinstance(c, dict), "Wrong type: %r Want: dict" % c
+    assert isinstance(p, Project), "Wrong type: {0!r} Want: Project".format(p)
+    assert isinstance(e, Experiment), "Wrong type: {0!r} Want: Experiment".format(e)
+    assert isinstance(c, dict), "Wrong type: {0!r} Want: dict".format(c)
 
     project_name = kwargs.get("project_name", p.name)
 
@@ -94,9 +94,9 @@ def run_with_papi(run_f, args, **kwargs):
     assert p is not None, "run_with_likwid.project attribute is None."
     assert e is not None, "run_with_likwid.experiment attribute is None."
     assert c is not None, "run_with_likwid.config attribute is None."
-    assert isinstance(p, Project), "Wrong type: %r Want: Project" % p
-    assert isinstance(e, Experiment), "Wrong type: %r Want: Experiment" % e
-    assert isinstance(c, dict), "Wrong type: %r Want: Experiment" % e
+    assert isinstance(p, Project), "Wrong type: {0!r} Want: Project".format(p)
+    assert isinstance(e, Experiment), "Wrong type: {0!r} Want: Experiment".format(e)
+    assert isinstance(c, dict), "Wrong type: {0!r} Want: Experiment".format(e)
 
     project_name = kwargs.get("project_name", p.name)
 
@@ -146,9 +146,9 @@ def run_with_likwid(run_f, args, **kwargs):
     assert p is not None, "run_with_likwid.project attribute is None."
     assert e is not None, "run_with_likwid.experiment attribute is None."
     assert c is not None, "run_with_likwid.config attribute is None."
-    assert isinstance(p, Project), "Wrong type: %r Want: Project" % p
-    assert isinstance(e, Experiment), "Wrong type: %r Want: Experiment" % e
-    assert isinstance(c, dict), "Wrong type: %r Want: Experiment" % e
+    assert isinstance(p, Project), "Wrong type: {0!r} Want: Project".format(p)
+    assert isinstance(e, Experiment), "Wrong type: {0!r} Want: Experiment".format(e)
+    assert isinstance(c, dict), "Wrong type: {0!r} Want: Experiment".format(e)
 
     project_name = kwargs.get("project_name", p.name)
     likwid_f = project_name + ".txt"
@@ -212,9 +212,9 @@ def run_with_time(run_f, args, **kwargs):
     assert p is not None, "run_with_likwid.project attribute is None."
     assert e is not None, "run_with_likwid.experiment attribute is None."
     assert c is not None, "run_with_likwid.config attribute is None."
-    assert isinstance(p, Project), "Wrong type: %r Want: Project" % p
-    assert isinstance(e, Experiment), "Wrong type: %r Want: Experiment" % e
-    assert isinstance(c, dict), "Wrong type: %r Want: dict" % c
+    assert isinstance(p, Project), "Wrong type: {0!r} Want: Project".format(p)
+    assert isinstance(e, Experiment), "Wrong type: {0!r} Want: Experiment".format(e)
+    assert isinstance(c, dict), "Wrong type: {0!r} Want: dict".format(c)
 
     project_name = kwargs.get("project_name", p.name)
     timing_tag = "PPROF-JIT: "
@@ -272,9 +272,9 @@ def run_with_perf(run_f, args, **kwargs):
     assert p is not None, "run_with_likwid.project attribute is None."
     assert e is not None, "run_with_likwid.experiment attribute is None."
     assert c is not None, "run_with_likwid.config attribute is None."
-    assert isinstance(p, Project), "Wrong type: %r Want: Project" % p
-    assert isinstance(e, Experiment), "Wrong type: %r Want: Experiment" % e
-    assert isinstance(c, dict), "Wrong type: %r Want: dict" % c
+    assert isinstance(p, Project), "Wrong type: {0!r} Want: Project".format(p)
+    assert isinstance(e, Experiment), "Wrong type: {0!r} Want: Experiment".format(e)
+    assert isinstance(c, dict), "Wrong type: {0!r} Want: dict".format(c)
 
     project_name = kwargs.get("project_name", p.name)
     run_cmd = local[run_f]

--- a/pprof/experiments/raw.py
+++ b/pprof/experiments/raw.py
@@ -60,9 +60,9 @@ def run_with_time(run_f, args, **kwargs):
     assert p is not None, "run_with_time.project attribute is None."
     assert e is not None, "run_with_time.experiment attribute is None."
     assert c is not None, "run_with_time.config attribute is None."
-    assert isinstance(p, Project), "Wrong type: %r Want: Project" % p
-    assert isinstance(e, Experiment), "Wrong type: %r Want: Experiment" % e
-    assert isinstance(c, dict), "Wrong type: %r Want: dict" % c
+    assert isinstance(p, Project), "Wrong type: {0!r} Want: Project".format(p)
+    assert isinstance(e, Experiment), "Wrong type: {0!r} Want: Experiment".format(e)
+    assert isinstance(c, dict), "Wrong type: {0!r} Want: dict".format(c)
 
     project_name = kwargs.get("project_name", p.name)
     timing_tag = "PPROF-TIME: "

--- a/pprof/utils/user_interface.py
+++ b/pprof/utils/user_interface.py
@@ -20,7 +20,7 @@ def query_yes_no(question, default="yes"):
     elif default == "no":
         prompt = " [y/N] "
     else:
-        raise ValueError("invalid default answer: '%s'" % default)
+        raise ValueError("invalid default answer: '{0!s}'".format(default))
 
     while True:
         sys.stdout.write(question + prompt)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:simbuerg:pprof-study?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:simbuerg:pprof-study?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)