### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/pprof/driver.py
+++ b/pprof/driver.py
@@ -67,7 +67,7 @@ class PollyProfiling(cli.Application):
         LOG.setLevel(log_levels[self.verbosity])
 
         if args:
-            print("Unknown command %r" % (args[0], ))
+            print("Unknown command {0!r}".format(args[0] ))
             return 1
         if not self.nested_command:
             print("No command given")

--- a/pprof/utils/user_interface.py
+++ b/pprof/utils/user_interface.py
@@ -26,7 +26,7 @@ def query_yes_no(question, default="yes"):
     elif default == "no":
         prompt = " [y/N] "
     else:
-        raise ValueError("invalid default answer: '%s'" % default)
+        raise ValueError("invalid default answer: '{0!s}'".format(default))
 
     while True:
         sys.stdout.write(question + prompt)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:simbuerg:pprof-study?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:simbuerg:pprof-study?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)